### PR TITLE
Allow running tests against physical hardware

### DIFF
--- a/clickplc/tests/test_driver.py
+++ b/clickplc/tests/test_driver.py
@@ -13,10 +13,6 @@ def plc_driver():
     return ClickPLC('fake ip')
 
 
-@pytest.fixture
-def tagged_driver():
-    """Confirm the driver correctly initializes with a good tags file."""
-    return ClickPLC('fake ip', 'clickplc/tests/plc_tags.csv')
 
 
 @pytest.fixture
@@ -66,10 +62,6 @@ def test_driver_cli_tags(capsys):
         command_line(['fakeip', 'tags', 'bogus'])
 
 
-def test_get_tags(tagged_driver, expected_tags):
-    """Confirm that the driver returns correct values on get() calls."""
-    assert expected_tags == tagged_driver.get_tags()
-
 
 def test_unsupported_tags():
     """Confirm the driver detects an improper tags file."""
@@ -78,12 +70,13 @@ def test_unsupported_tags():
 
 
 @pytest.mark.asyncio
-async def test_tagged_driver(tagged_driver, expected_tags):
+async def test_tagged_driver(expected_tags):
     """Test a roundtrip with the driver using a tags file."""
-    await tagged_driver.set('VAH_101_OK', True)
-    state = await tagged_driver.get()
-    assert state.get('VAH_101_OK')
-    assert expected_tags.keys() == state.keys()
+    async with ClickPLC('fakeip', 'clickplc/tests/plc_tags.csv') as tagged_driver:
+        await tagged_driver.set('VAH_101_OK', True)
+        state = await tagged_driver.get()
+        assert state.get('VAH_101_OK')
+        assert expected_tags == tagged_driver.get_tags()
 
 
 @pytest.mark.asyncio

--- a/clickplc/tests/test_driver.py
+++ b/clickplc/tests/test_driver.py
@@ -112,8 +112,8 @@ async def test_c_roundtrip(plc_driver):
 @pytest.mark.asyncio
 async def test_df_roundtrip(plc_driver):
     """Confirm df floats are read back correctly after being set."""
-    await plc_driver.set('df2', 2.0)
-    await plc_driver.set('df3', [3.0, 4.0])
+    await plc_driver.set('df1', 0.0)
+    await plc_driver.set('df2', [2.0, 3.0, 4.0, 0.0])
     expected = {'df1': 0.0, 'df2': 2.0, 'df3': 3.0, 'df4': 4.0, 'df5': 0.0}
     assert expected == await plc_driver.get('df1-df5')
 
@@ -159,6 +159,7 @@ async def test_get_xy_error_handling(plc_driver, prefix):
         await plc_driver.get(f'{prefix}1-{prefix}17')
     with pytest.raises(ValueError, match=r'address must be in \[001, 816\].'):
         await plc_driver.get(f'{prefix}1-{prefix}1001')
+
 
 @pytest.mark.asyncio
 async def test_set_y_error_handling(plc_driver):

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,4 @@ ignore_missing_imports = True
 
 [tool:pytest]
 addopts = --cov=clickplc
+asyncio_mode = auto


### PR DESCRIPTION
Closes #6.

Note that with `pytest-xdist` and multiple parallel tests, it's possible to attempt to establish too many TCP connections.  This was partially mitigated by using making the `plc_driver` session-scoped so it could be re-used by most tests.

