### PR TITLE
Add DH registers

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Currently, the following datatypes are supported:
 | ct | bool | (C)oun(t)er |
 | ds | int16 | (D)ata register, (s)ingle signed int |
 | dd | int32 | (D)ata register, (d)double signed int |
+| dh | uint16| (D) register, (h)ex |
 | df | float | (D)ata register, (f)loating point |
 | td | int16 | (T)ime (d)elay register |
 | ctd | int32 | (C)oun(t)er Current Values, (d)ouble int |

--- a/clickplc/tests/test_driver.py
+++ b/clickplc/tests/test_driver.py
@@ -136,6 +136,16 @@ async def test_dd_roundtrip(plc_driver):
     assert await plc_driver.get('dd1000') == 1000
 
 @pytest.mark.asyncio(scope='session')
+async def test_dh_roundtrip(plc_driver):
+    """Confirm dh single ints are read back correctly after being set."""
+    await plc_driver.set('dh1', 1)
+    await plc_driver.set('dh3', [3, 2**16 - 1])
+    expected = {'dh1': 1, 'dh2': 0, 'dh3': 3, 'dh4': 2**16 - 1, 'dh5': 0}
+    assert expected == await plc_driver.get('dh1-dh5')
+    await plc_driver.set('dh500', 500)
+    assert await plc_driver.get('dh500') == 500
+
+@pytest.mark.asyncio(scope='session')
 async def test_txt_roundtrip(plc_driver):
     """Confirm texts are read back correctly after being set."""
     await plc_driver.set('txt1', 'AB')
@@ -221,6 +231,17 @@ async def test_ct_error_handling(plc_driver):
     with pytest.raises(ValueError, match=r'CT end address must be >start and <=250.'):
         await plc_driver.get('ct1-ct251')
 
+@pytest.mark.asyncio(scope='session')
+async def test_dh_error_handling(plc_driver):
+    """Ensure errors are handled for invalid requests of df registers."""
+    with pytest.raises(ValueError, match=r'DH must be in \[1, 500\]'):
+        await plc_driver.get('dh501')
+    with pytest.raises(ValueError, match=r'DH end must be in \[1, 500\]'):
+        await plc_driver.get('dh1-dh501')
+    with pytest.raises(ValueError, match=r'DH must be in \[1, 500\]'):
+        await plc_driver.set('dh501', 1)
+    with pytest.raises(ValueError, match=r'Data list longer than available addresses.'):
+        await plc_driver.set('dh500', [1, 2])
 
 @pytest.mark.asyncio(scope='session')
 async def test_df_error_handling(plc_driver):


### PR DESCRIPTION
`DH` registers are shown in the ClickPLC editor as hexidecimal values.  Per a conversation with AutomationDirect, we can represent them at 16-bit unsigned ints.
