### PR TITLE
scope -> loop_scope

### DIFF
--- a/clickplc/tests/test_driver.py
+++ b/clickplc/tests/test_driver.py
@@ -61,13 +61,13 @@ def test_driver_cli_tags(capsys):
     with pytest.raises(SystemExit):
         command_line([ADDRESS, 'tags', 'bogus'])
 
-@pytest.mark.asyncio(scope='session')
+@pytest.mark.asyncio(loop_scope='session')
 async def test_unsupported_tags():
     """Confirm the driver detects an improper tags file."""
     with pytest.raises(TypeError, match='unsupported data type'):
         ClickPLC(ADDRESS, 'clickplc/tests/bad_tags.csv')
 
-@pytest.mark.asyncio(scope='session')
+@pytest.mark.asyncio(loop_scope='session')
 async def test_tagged_driver(expected_tags):
     """Test a roundtrip with the driver using a tags file."""
     async with ClickPLC(ADDRESS, 'clickplc/tests/plc_tags.csv') as tagged_driver:
@@ -76,7 +76,7 @@ async def test_tagged_driver(expected_tags):
         assert state.get('VAH_101_OK')
         assert expected_tags == tagged_driver.get_tags()
 
-@pytest.mark.asyncio(scope='session')
+@pytest.mark.asyncio(loop_scope='session')
 async def test_y_roundtrip(plc_driver):
     """Confirm y (output bools) are read back correctly after being set."""
     await plc_driver.set('y1', [False, True, False, True])
@@ -85,7 +85,7 @@ async def test_y_roundtrip(plc_driver):
     await plc_driver.set('y816', True)
     assert await plc_driver.get('y816') is True
 
-@pytest.mark.asyncio(scope='session')
+@pytest.mark.asyncio(loop_scope='session')
 async def test_c_roundtrip(plc_driver):
     """Confirm c bools are read back correctly after being set."""
     await plc_driver.set('c2', True)
@@ -95,7 +95,7 @@ async def test_c_roundtrip(plc_driver):
     await plc_driver.set('c2000', True)
     assert await plc_driver.get('c2000') is True
 
-@pytest.mark.asyncio(scope='session')
+@pytest.mark.asyncio(loop_scope='session')
 async def test_ds_roundtrip(plc_driver):
     """Confirm ds ints are read back correctly after being set."""
     await plc_driver.set('ds1', 1)
@@ -105,7 +105,7 @@ async def test_ds_roundtrip(plc_driver):
     await plc_driver.set('ds4500', 4500)
     assert await plc_driver.get('ds4500') == 4500
 
-@pytest.mark.asyncio(scope='session')
+@pytest.mark.asyncio(loop_scope='session')
 async def test_df_roundtrip(plc_driver):
     """Confirm df floats are read back correctly after being set."""
     await plc_driver.set('df1', 0.0)
@@ -115,7 +115,7 @@ async def test_df_roundtrip(plc_driver):
     await plc_driver.set('df500', 1.0)
     assert await plc_driver.get('df500') == 1.0
 
-@pytest.mark.asyncio(scope='session')
+@pytest.mark.asyncio(loop_scope='session')
 async def test_td_roundtrip(plc_driver):
     """Confirm td ints are read back correctly after being set."""
     await plc_driver.set('td1', 1)
@@ -125,7 +125,7 @@ async def test_td_roundtrip(plc_driver):
     await plc_driver.set('td500', 500)
     assert await plc_driver.get('td500') == 500
 
-@pytest.mark.asyncio(scope='session')
+@pytest.mark.asyncio(loop_scope='session')
 async def test_dd_roundtrip(plc_driver):
     """Confirm dd double ints are read back correctly after being set."""
     await plc_driver.set('dd1', 1)
@@ -135,7 +135,7 @@ async def test_dd_roundtrip(plc_driver):
     await plc_driver.set('dd1000', 1000)
     assert await plc_driver.get('dd1000') == 1000
 
-@pytest.mark.asyncio(scope='session')
+@pytest.mark.asyncio(loop_scope='session')
 async def test_dh_roundtrip(plc_driver):
     """Confirm dh single ints are read back correctly after being set."""
     await plc_driver.set('dh1', 1)
@@ -145,7 +145,7 @@ async def test_dh_roundtrip(plc_driver):
     await plc_driver.set('dh500', 500)
     assert await plc_driver.get('dh500') == 500
 
-@pytest.mark.asyncio(scope='session')
+@pytest.mark.asyncio(loop_scope='session')
 async def test_txt_roundtrip(plc_driver):
     """Confirm texts are read back correctly after being set."""
     await plc_driver.set('txt1', 'AB')
@@ -162,7 +162,7 @@ async def test_txt_roundtrip(plc_driver):
     assert await plc_driver.get('txt999') == '9'
     assert await plc_driver.get('txt1000') == '0'  # ensure txt999 did not clobber it
 
-@pytest.mark.asyncio(scope='session')
+@pytest.mark.asyncio(loop_scope='session')
 async def test_get_error_handling(plc_driver):
     """Confirm the driver gives an error on invalid get() calls."""
     with pytest.raises(ValueError, match='An address must be supplied'):
@@ -174,13 +174,13 @@ async def test_get_error_handling(plc_driver):
     with pytest.raises(ValueError, match='Inter-category ranges are unsupported'):
         await plc_driver.get('c1-x3')
 
-@pytest.mark.asyncio(scope='session')
+@pytest.mark.asyncio(loop_scope='session')
 async def test_set_error_handling(plc_driver):
     """Confirm the driver gives an error on invalid set() calls."""
     with pytest.raises(ValueError, match='foo currently unsupported'):
         await plc_driver.set('foo1', 1)
 
-@pytest.mark.asyncio(scope='session')
+@pytest.mark.asyncio(loop_scope='session')
 @pytest.mark.parametrize('prefix', ['x', 'y'])
 async def test_get_xy_error_handling(plc_driver, prefix):
     """Ensure errors are handled for invalid get requests of x and y registers."""
@@ -193,7 +193,7 @@ async def test_get_xy_error_handling(plc_driver, prefix):
     with pytest.raises(ValueError, match=r'address must be in \[001, 816\].'):
         await plc_driver.get(f'{prefix}1-{prefix}1001')
 
-@pytest.mark.asyncio(scope='session')
+@pytest.mark.asyncio(loop_scope='session')
 async def test_set_y_error_handling(plc_driver):
     """Ensure errors are handled for invalid set requests of y registers."""
     with pytest.raises(ValueError, match=r'address must be \*01-\*16.'):
@@ -203,7 +203,7 @@ async def test_set_y_error_handling(plc_driver):
     with pytest.raises(ValueError, match=r'Data list longer than available addresses.'):
         await plc_driver.set('y816', [True, True])
 
-@pytest.mark.asyncio(scope='session')
+@pytest.mark.asyncio(loop_scope='session')
 async def test_c_error_handling(plc_driver):
     """Ensure errors are handled for invalid requests of c registers."""
     with pytest.raises(ValueError, match=r'C start address must be 1-2000.'):
@@ -215,7 +215,7 @@ async def test_c_error_handling(plc_driver):
     with pytest.raises(ValueError, match=r'Data list longer than available addresses.'):
         await plc_driver.set('c2000', [True, True])
 
-@pytest.mark.asyncio(scope='session')
+@pytest.mark.asyncio(loop_scope='session')
 async def test_t_error_handling(plc_driver):
     """Ensure errors are handled for invalid requests of t registers."""
     with pytest.raises(ValueError, match=r'T start address must be 1-500.'):
@@ -223,7 +223,7 @@ async def test_t_error_handling(plc_driver):
     with pytest.raises(ValueError, match=r'T end address must be >start and <=500.'):
         await plc_driver.get('t1-t501')
 
-@pytest.mark.asyncio(scope='session')
+@pytest.mark.asyncio(loop_scope='session')
 async def test_ct_error_handling(plc_driver):
     """Ensure errors are handled for invalid requests of ct registers."""
     with pytest.raises(ValueError, match=r'CT start address must be 1-250.'):
@@ -231,7 +231,7 @@ async def test_ct_error_handling(plc_driver):
     with pytest.raises(ValueError, match=r'CT end address must be >start and <=250.'):
         await plc_driver.get('ct1-ct251')
 
-@pytest.mark.asyncio(scope='session')
+@pytest.mark.asyncio(loop_scope='session')
 async def test_dh_error_handling(plc_driver):
     """Ensure errors are handled for invalid requests of df registers."""
     with pytest.raises(ValueError, match=r'DH must be in \[1, 500\]'):
@@ -243,7 +243,7 @@ async def test_dh_error_handling(plc_driver):
     with pytest.raises(ValueError, match=r'Data list longer than available addresses.'):
         await plc_driver.set('dh500', [1, 2])
 
-@pytest.mark.asyncio(scope='session')
+@pytest.mark.asyncio(loop_scope='session')
 async def test_df_error_handling(plc_driver):
     """Ensure errors are handled for invalid requests of df registers."""
     with pytest.raises(ValueError, match=r'DF must be in \[1, 500\]'):
@@ -255,7 +255,7 @@ async def test_df_error_handling(plc_driver):
     with pytest.raises(ValueError, match=r'Data list longer than available addresses.'):
         await plc_driver.set('df500', [1.0, 2.0])
 
-@pytest.mark.asyncio(scope='session')
+@pytest.mark.asyncio(loop_scope='session')
 async def test_ds_error_handling(plc_driver):
     """Ensure errors are handled for invalid requests of ds registers."""
     with pytest.raises(ValueError, match=r'DS must be in \[1, 4500\]'):
@@ -267,7 +267,7 @@ async def test_ds_error_handling(plc_driver):
     with pytest.raises(ValueError, match=r'Data list longer than available addresses.'):
         await plc_driver.set('ds4500', [1, 2])
 
-@pytest.mark.asyncio(scope='session')
+@pytest.mark.asyncio(loop_scope='session')
 async def test_dd_error_handling(plc_driver):
     """Ensure errors are handled for invalid requests of dd registers."""
     with pytest.raises(ValueError, match=r'DD must be in \[1, 1000\]'):
@@ -279,7 +279,7 @@ async def test_dd_error_handling(plc_driver):
     with pytest.raises(ValueError, match=r'Data list longer than available addresses.'):
         await plc_driver.set('dd1000', [1, 2])
 
-@pytest.mark.asyncio(scope='session')
+@pytest.mark.asyncio(loop_scope='session')
 async def test_td_error_handling(plc_driver):
     """Ensure errors are handled for invalid requests of td registers."""
     with pytest.raises(ValueError, match=r'TD must be in \[1, 500\]'):
@@ -287,7 +287,7 @@ async def test_td_error_handling(plc_driver):
     with pytest.raises(ValueError, match=r'TD end must be in \[1, 500\]'):
         await plc_driver.get('td1-td501')
 
-@pytest.mark.asyncio(scope='session')
+@pytest.mark.asyncio(loop_scope='session')
 async def test_ctd_error_handling(plc_driver):
     """Ensure errors are handled for invalid requests of ctd registers."""
     with pytest.raises(ValueError, match=r'CTD must be in \[1, 250\]'):
@@ -295,7 +295,7 @@ async def test_ctd_error_handling(plc_driver):
     with pytest.raises(ValueError, match=r'CTD end must be in \[1, 250\]'):
         await plc_driver.get('ctd1-ctd251')
 
-@pytest.mark.asyncio(scope='session')
+@pytest.mark.asyncio(loop_scope='session')
 @pytest.mark.parametrize('prefix', ['y', 'c'])
 async def test_bool_typechecking(plc_driver, prefix):
     """Ensure errors are handled for set() requests that should be bools."""
@@ -304,7 +304,7 @@ async def test_bool_typechecking(plc_driver, prefix):
     with pytest.raises(ValueError, match='Expected .+ as a bool'):
         await plc_driver.set(f'{prefix}1', [1.0, 1])
 
-@pytest.mark.asyncio(scope='session')
+@pytest.mark.asyncio(loop_scope='session')
 async def test_df_typechecking(plc_driver):
     """Ensure errors are handled for set() requests that should be floats."""
     await plc_driver.set('df1', 1)
@@ -313,7 +313,7 @@ async def test_df_typechecking(plc_driver):
     with pytest.raises(ValueError, match='Expected .+ as a float'):
         await plc_driver.set('df1', [True, True])
 
-@pytest.mark.asyncio(scope='session')
+@pytest.mark.asyncio(loop_scope='session')
 @pytest.mark.parametrize('prefix', ['ds', 'dd'])
 async def test_ds_dd_typechecking(plc_driver, prefix):
     """Ensure errors are handled for set() requests that should be ints."""


### PR DESCRIPTION
PytestDeprecationWarning: The "scope" keyword argument to the asyncio marker has been deprecated. Please use the "loop_scope" argument instead.﻿
