### PR TITLE
Add sd/sc to allow setting date/time in Click PLC

### DIFF
--- a/clickplc/driver.py
+++ b/clickplc/driver.py
@@ -459,10 +459,10 @@ class ClickPLC(AsyncioModbusClient):
         SD entries start at Modbus address 361440 (361441 in the Click software's
         1-indexed notation). Each SD entry takes 16 bits.
         """
-        if start < 1 or start > 4500:
-            raise ValueError('SD must be in [1, 4500]')
-        if end is not None and (end < 1 or end > 4500):
-            raise ValueError('SD end must be in [1, 4500]')
+        if start < 1 or start > 1000:
+            raise ValueError('SD must be in [1, 1000]')
+        if end is not None and (end < 1 or end > 1000):
+            raise ValueError('SD end must be in [1, 1000]')
 
         address = 61440 + start - 1
         count = 1 if end is None else (end - start + 1)

--- a/clickplc/driver.py
+++ b/clickplc/driver.py
@@ -326,7 +326,7 @@ class ClickPLC(AsyncioModbusClient):
 
         coils = await self.read_coils(start_coil, count)
         return {f'ct{(start + i)}': bit for i, bit in enumerate(coils.bits) if i < count}
-    
+
     async def _get_sc(self, start: int, end: int | None) -> dict | bool:
         """Read SC addresses. Called by `get`.
 
@@ -592,7 +592,7 @@ class ClickPLC(AsyncioModbusClient):
             await self.write_coils(coil, data)
         else:
             await self.write_coil(coil, data)
-            
+
     async def _set_sc(self, start: int, data: list[bool] | bool):
         """Set SC addresses. Called by `set`.
 
@@ -604,7 +604,7 @@ class ClickPLC(AsyncioModbusClient):
             data: Single value or list of values to set.
 
         Raises:
-            ValueError: If the start address is out of range or is not writable, 
+            ValueError: If the start address is out of range or is not writable,
                 or if the data list exceeds the allowed writable range.
 
         Notes:
@@ -761,7 +761,7 @@ class ClickPLC(AsyncioModbusClient):
             await self.write_registers(address, payload, skip_encode=True)
         else:
             await self.write_register(address, _pack([data]), skip_encode=True)
-            
+
     async def _set_sd(self, start: int, data: list[int] | int):
         """Set writable SD registers. Called by `set`.
 

--- a/clickplc/driver.py
+++ b/clickplc/driver.py
@@ -612,7 +612,19 @@ class ClickPLC(AsyncioModbusClient):
             SC50, SC51, SC53, SC55, SC60, SC61, SC65, SC66, SC67, SC75, SC76, SC120, SC121.
         """
         writable_sc_addresses = {
-            50, 51, 53, 55, 60, 61, 65, 66, 67, 75, 76, 120, 121
+            50,  # _PLC_Mode_Change_to_STOP
+            51,  # _Watchdog_Timer_Reset
+            53,  # _RTC_Date_Change
+            55,  # _RTC_Time_Change
+            60,  # _BT_Disable_Pairing  (Plus only?)
+            61,  # _BT_Activate_Pairing (Plus only?)
+            65,  # _SD_Eject
+            66,  # _SD_Delete_All
+            67,  # _SD_Copy_System
+            75,  # _WLAN_Reset (Plus only?)
+            76,  # _Sub_CPU_Reset,
+            120, # _Network_Time_Request
+            121, # _Network_Time_DST
         }
 
         if start < 1 or start > 1000:

--- a/clickplc/driver.py
+++ b/clickplc/driver.py
@@ -33,7 +33,7 @@ class ClickPLC(AsyncioModbusClient):
         'c': 'bool',     # (C)ontrol relay
         't': 'bool',     # (T)imer
         'ct': 'bool',    # (C)oun(t)er
-        'sc': 'bool',    # (S)ystem (c)ontrol relays
+        'sc': 'bool',    # (S)ystem (c)ontrol relay
         'ds': 'int16',   # (D)ata register (s)ingle
         'dd': 'int32',   # (D)ata register, (d)ouble
         'dh': 'int16',   # (D)ata register, (h)ex
@@ -796,17 +796,17 @@ class ClickPLC(AsyncioModbusClient):
             SD140, SD141, SD142, SD143, SD144, SD145, SD146, SD147,
             SD214, SD215
         """
-        writable_sd_addresses = {
+        writable_sd_addresses = (
             29, 31, 32, 34, 35, 36, 40, 41, 42, 50, 51, 60, 61, 106, 107, 108,
             112, 113, 114, 140, 141, 142, 143, 144, 145, 146, 147, 214, 215
-        }
+        )
 
         def validate_address(address: int):
             if address not in writable_sd_addresses:
                 raise ValueError(f"SD{address} is not writable. Only specific SD registers are writable.")
 
         if isinstance(data, list):
-            for idx, value in enumerate(data):
+            for idx, _ in enumerate(data):
                 validate_address(start + idx)
         else:
             validate_address(start)

--- a/clickplc/driver.py
+++ b/clickplc/driver.py
@@ -610,10 +610,11 @@ class ClickPLC(AsyncioModbusClient):
         Notes:
             Only the following SC addresses are writable:
             SC50, SC51, SC53, SC55, SC60, SC61, SC65, SC66, SC67, SC75, SC76, SC120, SC121.
+            (SC50 and SC51 may actually be read-only!)
         """
         writable_sc_addresses = {
-            50,  # _PLC_Mode_Change_to_STOP
-            51,  # _Watchdog_Timer_Reset
+            50,  # _PLC_Mode_Change_to_STOP - FIXME: may not be writeable
+            51,  # _Watchdog_Timer_Reset - FIXME: may not be writeable
             53,  # _RTC_Date_Change
             55,  # _RTC_Time_Change
             60,  # _BT_Disable_Pairing  (Plus only?)

--- a/clickplc/driver.py
+++ b/clickplc/driver.py
@@ -255,7 +255,7 @@ class ClickPLC(AsyncioModbusClient):
         """Read C addresses. Called by `get`.
 
         C entries start at 16384 (16385 in the Click software's 1-indexed
-        notation). This continues for 2000 bits, ending at 18383.
+        notation) and span a total of 2000 bits, ending at 18383.
 
         The response always returns a full byte of data. If you request
         a number of addresses not divisible by 8, it will have extra data. The
@@ -279,7 +279,7 @@ class ClickPLC(AsyncioModbusClient):
         """Read T addresses.
 
         T entries start at 45056 (45057 in the Click software's 1-indexed
-        notation). This continues for 500 bits, ending at 45555.
+        notation) and span a total of 500 bits, ending at 45555.
 
         The response always returns a full byte of data. If you request
         a number of addresses not divisible by 8, it will have extra data. The
@@ -304,7 +304,7 @@ class ClickPLC(AsyncioModbusClient):
         """Read CT addresses.
 
         CT entries start at 49152 (49153 in the Click software's 1-indexed
-        notation). This continues for 250 bits, ending at 49402.
+        notation) and span a total of 250 bits, ending at 49401.
 
         The response always returns a full byte of data. If you request
         a number of addresses not divisible by 8, it will have extra data. The

--- a/clickplc/driver.py
+++ b/clickplc/driver.py
@@ -113,7 +113,7 @@ class ClickPLC(AsyncioModbusClient):
         category, start_index = start[:i].lower(), int(start[i:])
         end_index = None if end is None else int(end[i:])
 
-        if end_index is not None and end_index < start_index:
+        if end_index is not None and end_index <= start_index:
             raise ValueError("End address must be greater than start address.")
         if category not in self.data_types:
             raise ValueError(f"{category} currently unsupported.")
@@ -346,8 +346,8 @@ class ClickPLC(AsyncioModbusClient):
         """
         if start < 1 or start > 1000:
             raise ValueError('SC start address must be in [1, 1000]')
-        if end is not None and (end < start or end > 1000):
-            raise ValueError('SC end address must be in [start, 1000]')
+        if end is not None and (end <= start or end > 1000):
+            raise ValueError("SC end address must be >= start and <= 1000.")
 
         start_coil = 61440 + (start - 1)  # Modbus coil address for SC
         if end is None:

--- a/clickplc/tests/test_driver.py
+++ b/clickplc/tests/test_driver.py
@@ -188,7 +188,7 @@ async def test_sd_roundtrip(plc_driver):
         await plc_driver.set('sd63', 500)
 
 @pytest.mark.asyncio(loop_scope='session')
-async def test_sd_set_date(plc_driver):
+async def test_set_date(plc_driver):
     """Test setting the date components (SD29, SD31, SD32) and triggering SC53 to update the RTC date."""
     # Set date values
     await plc_driver.set('sd29', 2024)  # Year
@@ -211,7 +211,7 @@ async def test_sd_set_date(plc_driver):
     assert await plc_driver.get('sd32') == 25
 
 @pytest.mark.asyncio(loop_scope='session')
-async def test_sd_set_time(plc_driver):
+async def test_set_time(plc_driver):
     """Test setting the time components (SD34, SD35, SD36) and triggering SC55 to update the RTC time."""
     # Set time values
     await plc_driver.set('sd34', 12)   # Hour

--- a/clickplc/tests/test_driver.py
+++ b/clickplc/tests/test_driver.py
@@ -99,9 +99,10 @@ async def test_c_roundtrip(plc_driver):
 @pytest.mark.asyncio(loop_scope='session')
 async def test_sc_roundtrip(plc_driver):
     """Confirm writable SC bools are read back correctly after being set."""
+    # FIXME docs say this is writable, but firmware 3.60 says read-only
     # Test writing to SC50 (_PLC_Mode_Change_to_STOP) to stop PLC mode
-    await plc_driver.set('sc50', True)
-    assert await plc_driver.get('sc50') is True
+    # await plc_driver.set('sc50', True)
+    # assert await plc_driver.get('sc50') is True
 
     # Test writing to SC60 and SC61 (_BT_Disable_Pairing, _BT_Activate_Pairing) to
     # manage Bluetooth pairing
@@ -317,7 +318,7 @@ async def test_sc_error_handling(plc_driver):
     # Test invalid range crossing writable boundaries
     with pytest.raises(ValueError, match=r'SC52 is not writable.'):
         # Range includes non-writable SC
-        await plc_driver.set('sc50', [True, True, True, True])
+        await plc_driver.set('sc52', [True, True])
 
     # Test data type mismatch
     with pytest.raises(ValueError, match=r"Expected sc50 as a bool."):

--- a/clickplc/tests/test_driver.py
+++ b/clickplc/tests/test_driver.py
@@ -193,7 +193,7 @@ async def test_set_date(plc_driver):
     await asyncio.sleep(1)  # Wait for the update to process
 
     # Confirm no errors
-    assert not await plc_driver.get('sc54'), "SC54 indicates a date update error."
+    assert await plc_driver.get('sc54') == 0, "SC54 indicates a date update error."
 
     # Turn SC53 OFF
     await plc_driver.set('sc53', False)
@@ -207,16 +207,16 @@ async def test_set_date(plc_driver):
 async def test_set_time(plc_driver):
     """Test setting the time components (SD34, SD35, SD36) and triggering SC55 to update the RTC time."""
     # Set time values
-    await plc_driver.set('sd34', 12)   # Hour
-    await plc_driver.set('sd35', 30)   # Minute
-    await plc_driver.set('sd36', 45)   # Second
+    await plc_driver.set('sd34', 12)  # Hour
+    await plc_driver.set('sd35', 30)  # Minute
+    await plc_driver.set('sd36', 45)  # Second
 
     # Trigger the update
     await plc_driver.set('sc55', True)
     await asyncio.sleep(1)  # Wait for the update to process
 
     # Confirm no errors
-    assert not await plc_driver.get('sc56'), "SC56 indicates a time update error."
+    assert await plc_driver.get('sc56') == 0, "SC56 indicates a time update error."
 
     # Turn SC55 OFF
     await plc_driver.set('sc55', False)

--- a/clickplc/tests/test_driver.py
+++ b/clickplc/tests/test_driver.py
@@ -400,13 +400,6 @@ async def test_sd_error_handling(plc_driver):
     with pytest.raises(ValueError, match=r'SD63 is not writable.'):
         await plc_driver.set('sd63', 1)  # Read-only SD register
 
-    # Test writable boundaries
-    writable_addresses = {29, 31, 32, 34, 35, 36, 40, 41, 42, 50, 51, 60, 61, 106, 107, 108,
-                          112, 113, 114, 140, 141, 142, 143, 144, 145, 146, 147, 214, 215}
-    for address in writable_addresses:
-        await plc_driver.set(f'sd{address}', 1234)  # Valid writable address
-        assert await plc_driver.get(f'sd{address}') == 1234
-
     # Test type mismatch
     with pytest.raises(ValueError, match=r'Expected sd29 as a int.'):
         await plc_driver.set('sd29', 'string')  # SD expects an integer value

--- a/clickplc/tests/test_driver.py
+++ b/clickplc/tests/test_driver.py
@@ -115,7 +115,7 @@ async def test_sc_roundtrip(plc_driver):
     # Test error handling for non-writable SC62 (_BT_Paired_Devices)
     with pytest.raises(ValueError, match="SC62 is not writable"):
         await plc_driver.set('sc62', True)
-    
+
     # Test error handling for non-writable SC63 (_BT_Pairing_SW_State)
     with pytest.raises(ValueError, match="SC63 is not writable"):
         await plc_driver.set('sc63', False)
@@ -170,7 +170,7 @@ async def test_dh_roundtrip(plc_driver):
     assert expected == await plc_driver.get('dh1-dh5')
     await plc_driver.set('dh500', 500)
     assert await plc_driver.get('dh500') == 500
-    
+
 @pytest.mark.asyncio(loop_scope='session')
 async def test_sd_roundtrip(plc_driver):
     """Confirm writable SD ints are read back correctly after being set."""
@@ -269,7 +269,7 @@ async def test_c_error_handling(plc_driver):
         await plc_driver.set('c2001', True)
     with pytest.raises(ValueError, match=r'Data list longer than available addresses.'):
         await plc_driver.set('c2000', [True, True])
-        
+
 @pytest.mark.asyncio(loop_scope='session')
 async def test_sc_error_handling(plc_driver):
     """Ensure errors are handled for invalid requests of SC registers."""
@@ -296,7 +296,7 @@ async def test_sc_error_handling(plc_driver):
     # Test invalid range crossing writable boundaries
     with pytest.raises(ValueError, match=r'SC53 is writable but SC52 is not.'):
         # Range includes non-writable SC
-        await plc_driver.set('sc52-sc55', [True, True, True, True])  
+        await plc_driver.set('sc52-sc55', [True, True, True, True])
 
     # Test data list exceeding writable addresses
     with pytest.raises(ValueError, match=r'Data list longer than available SC addresses.'):
@@ -386,7 +386,7 @@ async def test_ctd_error_handling(plc_driver):
         await plc_driver.get('ctd251')
     with pytest.raises(ValueError, match=r'CTD end must be in \[1, 250\]'):
         await plc_driver.get('ctd1-ctd251')
-        
+
 @pytest.mark.asyncio(loop_scope='session')
 async def test_sd_error_handling(plc_driver):
     """Ensure errors are handled for invalid requests of SD registers."""

--- a/clickplc/tests/test_driver.py
+++ b/clickplc/tests/test_driver.py
@@ -117,10 +117,6 @@ async def test_sc_roundtrip(plc_driver):
     with pytest.raises(ValueError, match="SC62 is not writable"):
         await plc_driver.set('sc62', True)
 
-    # Test error handling for non-writable SC63 (_BT_Pairing_SW_State)
-    with pytest.raises(ValueError, match="SC63 is not writable"):
-        await plc_driver.set('sc63', False)
-
 
 @pytest.mark.asyncio(loop_scope='session')
 async def test_ds_roundtrip(plc_driver):
@@ -182,10 +178,6 @@ async def test_sd_roundtrip(plc_driver):
     # Test error handling for non-writable SD62 (_BT_Paired_Device_Count)
     with pytest.raises(ValueError, match="SD62 is not writable"):
         await plc_driver.set('sd62', 5)
-
-    # Test error handling for non-writable SD63 (_SD_Total_Memory_L)
-    with pytest.raises(ValueError, match="SD63 is not writable"):
-        await plc_driver.set('sd63', 500)
 
 @pytest.mark.asyncio(loop_scope='session')
 async def test_set_date(plc_driver):
@@ -306,10 +298,6 @@ async def test_c_error_handling(plc_driver):
 @pytest.mark.asyncio(loop_scope='session')
 async def test_sc_error_handling(plc_driver):
     """Ensure errors are handled for invalid requests of SC registers."""
-    # Test valid boundary
-    await plc_driver.set('sc50', True)  # Valid writable address
-    assert await plc_driver.get('sc50') is True
-
     # Test invalid boundary (below range)
     with pytest.raises(ValueError, match=r'SC start address must be in \[1, 1000\]'):
         await plc_driver.set('sc0', True)  # Below valid range


### PR DESCRIPTION
Hello, Thanks for the library!

I wrote a short script to sync all my clicks on the network with my computer's clock. [sync_clickplc_datetime.py](https://gist.github.com/ssweber/5a860dab0f68467041a62e0eacc6ccc7) I then realized that writing SD, and read/writing SC wasn't added yet. I added necessary changes / modeling them after the C and DS corresponding functions. I tested my script, and it did set correctly!

Let me know if it looks OK. Thanks