### PR TITLE
Test on 3.7.x

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        pymodbus-version: ["2.5.3", "3.0.2", "3.1.3", "3.2.2", "3.3.1", "3.4.1", "3.5.4", "3.6.9"]
+        pymodbus-version: ["2.5.3", "3.0.2", "3.1.3", "3.2.2", "3.3.1", "3.4.1", "3.5.4", "3.6.9", "3.7.4"]
         exclude:
         - python-version: "3.10"
           pymodbus-version: "2.5.3"


### PR DESCRIPTION
the bug with `3.7.0` appears to have been fixed upstream.  Closes #42
