### PR TITLE
Remove single write methods

### DIFF
--- a/clickplc/mock.py
+++ b/clickplc/mock.py
@@ -11,12 +11,12 @@ from unittest.mock import MagicMock
 
 try:  # pymodbus >= 3.7.0
     from pymodbus.pdu.bit_read_message import ReadCoilsResponse, ReadDiscreteInputsResponse
-    from pymodbus.pdu.bit_write_message import WriteMultipleCoilsResponse, WriteSingleCoilResponse
+    from pymodbus.pdu.bit_write_message import WriteMultipleCoilsResponse
     from pymodbus.pdu.register_read_message import ReadHoldingRegistersResponse
     from pymodbus.pdu.register_write_message import WriteMultipleRegistersResponse
 except ImportError:
     from pymodbus.bit_read_message import ReadCoilsResponse, ReadDiscreteInputsResponse  # type: ignore
-    from pymodbus.bit_write_message import WriteMultipleCoilsResponse, WriteSingleCoilResponse  # type: ignore
+    from pymodbus.bit_write_message import WriteMultipleCoilsResponse  # type: ignore
     from pymodbus.register_read_message import ReadHoldingRegistersResponse  # type: ignore
     from pymodbus.register_write_message import WriteMultipleRegistersResponse  # type: ignore
 from pymodbus.constants import Endian
@@ -64,10 +64,6 @@ class ClickPLC(realClickPLC):
             return ReadHoldingRegistersResponse([int.from_bytes(self._registers[address + i],
                                                                 byteorder='big')
                                                  for i in range(count)])
-        elif method == 'write_coil':
-            address, data = args
-            self._coils[address] = data
-            return WriteSingleCoilResponse(address, data)
         elif method == 'write_coils':
             address, data = args
             for i, d in enumerate(data):

--- a/clickplc/util.py
+++ b/clickplc/util.py
@@ -80,17 +80,9 @@ class AsyncioModbusClient:
         registers += r.registers
         return registers
 
-    async def write_coil(self, address: int, value):
-        """Write modbus coils."""
-        await self._request('write_coil', address, value)
-
     async def write_coils(self, address: int, values):
         """Write modbus coils."""
         await self._request('write_coils', address, values)
-
-    async def write_register(self, address: int, value, skip_encode=False):
-        """Write a modbus register."""
-        await self._request('write_register', address, value, skip_encode=skip_encode)
 
     async def write_registers(self, address: int, values, skip_encode=False):
         """Write modbus registers.


### PR DESCRIPTION
They have never been used, and the tiny overhead of e.g. `write_registers()` versus `write_register()` is insignificant.
